### PR TITLE
Fixed crash if there are no clients

### DIFF
--- a/server.js
+++ b/server.js
@@ -132,9 +132,11 @@ io.on("connect", (socket) => {
         } catch (err) {}
     } else if (refresh == "true" && token != null) {
         socket.on("refresh", () => {
-            clients[token].forEach((socket) => {
-                socket.emit("refresh");
-            });
+            try {
+                clients[token].forEach((socket) => {
+                    socket.emit("refresh");
+                });
+            } catch (err) {}
         });
     } else {
         //Client connected


### PR DESCRIPTION
If there were no goal bars active on OBS or on a web page, the socket would crash trying to send a refresh request to the right clients. Since there were no clients, the clients object would be null and result in a crash.